### PR TITLE
Allow CSV data upload

### DIFF
--- a/templates/layouts/layout_without_sidebar.html
+++ b/templates/layouts/layout_without_sidebar.html
@@ -10,7 +10,7 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Fontawesome -->
         <link href="/static/fontawesome/css/all.min.css" rel="stylesheet">
-        <!-- costum CSS -->
+        <!-- custom CSS -->
         <link href="/static/css/styles.css" rel="stylesheet">
 
         <title>{% block title %}{% endblock %} &#149; tseapy</title>

--- a/templates/parameters/list_parameter.html
+++ b/templates/parameters/list_parameter.html
@@ -7,7 +7,7 @@
            onclick="{{p.onclick}}"
            {% if p.disabled %} disabled {% endif %}
     >
-    <datalist id="list_name">
+    <datalist id="list_{{p.name}}">
         {% for v in p.values %}
           <option value="{{ v }}">
         {% endfor %}

--- a/templates/upload.html
+++ b/templates/upload.html
@@ -1,0 +1,20 @@
+{% extends "layouts/layout_without_sidebar.html" %}
+
+{% block title %}Upload Data{% endblock %}
+
+{% block heading %}
+  <h1>Upload Data</h1>
+{% endblock %}
+
+{% block content %}
+  {% if error %}
+    <div class="alert alert-danger" role="alert">{{ error }}</div>
+  {% endif %}
+  <form action="/upload-data" method="post" enctype="multipart/form-data">
+    <div class="mb-3">
+      <label for="file" class="form-label">CSV File</label>
+      <input class="form-control" type="file" id="file" name="file">
+    </div>
+    <button type="submit" class="btn btn-primary">Upload</button>
+  </form>
+{% endblock %}

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,0 +1,22 @@
+import io
+from unittest import TestCase
+
+from app import app, cache
+
+class TestUpload(TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        cache.clear()
+
+    def test_upload_valid_csv(self):
+        csv = "date,value\n2021-01-01,1\n2021-01-02,2\n"
+        response = self.client.post('/upload-data', data={'file': (io.BytesIO(csv.encode()), 'data.csv')}, content_type='multipart/form-data')
+        self.assertEqual(response.status_code, 302)
+        df = cache.get('data')
+        self.assertIsNotNone(df)
+        self.assertEqual(df.iloc[0]['value'], 1)
+
+    def test_upload_invalid_csv(self):
+        csv = "a,b\n1,2\n3,4\n"
+        response = self.client.post('/upload-data', data={'file': (io.BytesIO(csv.encode()), 'data.csv')}, content_type='multipart/form-data')
+        self.assertEqual(response.status_code, 400)


### PR DESCRIPTION
## Summary
- add upload route and template so users can upload CSV data files
- validate uploaded data and store it in cache
- redirect to upload page when no data present
- fix datalist id in parameter template
- correct typo in layout template
- add tests covering valid and invalid CSV uploads

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_686d30d950c483249405e9b9d7de045c