### PR TITLE
Fix layout comment typo

### DIFF
--- a/templates/layouts/layout_without_sidebar.html
+++ b/templates/layouts/layout_without_sidebar.html
@@ -10,7 +10,7 @@
         <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
         <!-- Fontawesome -->
         <link href="/static/fontawesome/css/all.min.css" rel="stylesheet">
-        <!-- costum CSS -->
+        <!-- custom CSS -->
         <link href="/static/css/styles.css" rel="stylesheet">
 
         <title>{% block title %}{% endblock %} &#149; tseapy</title>


### PR DESCRIPTION
## Summary
- fix comment typo in layout without sidebar HTML template

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_b_686d3220ad0c8324ae43a442bfb5df8c